### PR TITLE
Fix #18 - do not set color in loadActorState

### DIFF
--- a/lib/vtk_utils.js
+++ b/lib/vtk_utils.js
@@ -88,7 +88,6 @@ function objToPolyData(json, includeTypes) {
     GEOM_TYPES.forEach(function (type, tIdx) {
         typeInfo[type] = {};
         if (includeTypes.indexOf(type) < 0) {
-            //rsUtils.rsdbg('Ignoring data for type', type);
             return;
         }
 
@@ -133,7 +132,6 @@ function objToPolyData(json, includeTypes) {
     let pd = vtk.Common.DataModel.vtkPolyData.newInstance();
     pd.getPoints().setData(points, 3);
 
-    //rsUtils.rsdbg('setting polydata from', tData);
     if (tData.lines) {
         pd.getLines().setData(tData.lines);
     }

--- a/lib/vtk_viewer.js
+++ b/lib/vtk_viewer.js
@@ -14,14 +14,14 @@ const SCALAR_ARRAY = 'scalars';
 
 const PICKABLE_TYPES = [vtkUtils.GEOM_TYPE_POLYS, vtkUtils.GEOM_TYPE_VECTS];
 
-let template = [
-    '<div class="vtk-widget" style="border-style: solid; border-color: #d9edf7; border-width: 1px;">',
-        '<div class="viewer-title" style="font-weight: normal; text-align: center"></div>',
-        '<div style="margin: 1em;">',
-            '<div class="vtk-content"></div>',
-        '</div>',
-    '</div>',
-].join('');
+let template = `
+    <div class="vtk-widget" style="border-style: solid; border-color: #d9edf7; border-width: 1px;">
+        <div class="viewer-title" style="font-weight: normal; text-align: center"></div>
+        <div style="margin: 1em;">
+            <div class="vtk-content"></div>
+        </div>
+    </div>
+`;
 
 // these objects are used to set various vector properties
 let vectInArrays = [{
@@ -314,7 +314,6 @@ var VTKView = widgets.DOMWidgetView.extend({
             return;
         }
         const info = this.getInfoForActor(this.getActor(name));
-        this.setColor(info, info.type, s.color, s.alpha);
         this.fsRenderer.getRenderWindow().render();
     },
 


### PR DESCRIPTION
If a user control-clicks an object to select it, the color still gets set uniformly.  The problem is selecting a single polygon vs. the whole object, and a good UI for that, which will be its own issue